### PR TITLE
Minor fix in setup.py

### DIFF
--- a/python/smurff/setup.py.in
+++ b/python/smurff/setup.py.in
@@ -52,5 +52,5 @@ setup(
     author_email = "Tom.VanderAa@imec.be",
     classifiers = CLASSIFIERS,
     keywords = "bayesian factorization machine-learning high-dimensional side-information",
-    install_requires = ['numpy', 'scipy', 'pandas', 'sklearn', 'matrix_io']
+    install_requires = ['numpy', 'scipy', 'pandas', 'scikit-learn', 'matrix_io']
 )


### PR DESCRIPTION
This should be scikit-learn, not sklearn to avoid pip install gives errors like:
"ERROR: smurff 0.14.3 requires sklearn, which is not installed."