### PR TITLE
Use vcpkg on Windows and macOS

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
           os: [ubuntu-latest, windows-latest, macos-13, macos-14]
-          python: [ "3.8", "3.9", "3.10", "3.11"]
+          python: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
           os: [ubuntu-latest, windows-latest, macos-13, macos-14]
-          pyver: [cp39, cp310, cp311, cp312]
+          pyver: [cp39, cp310, cp311, cp312, cp313]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,3 +37,11 @@ jobs:
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
+
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build_wheels
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: wheel ${{ matrix.pyver }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -35,11 +35,12 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          name: cibw-wheels-${{ matrix.os }}-${{ matrix.pyver }}
           path: ./wheelhouse/*.whl
 
 
   merge:
+    name: merge all wheel artifacts
     runs-on: ubuntu-latest
     needs: build_wheels
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.18.1
+        run: python -m pip install cibuildwheel
 
       - name: Build wheels
         env:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,6 +16,8 @@ jobs:
           pyver: [cp39, cp310, cp311, cp312]
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,6 +22,8 @@ jobs:
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.18.1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,8 +12,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-          os: [ubuntu-latest, macos-13, macos-14]
+          os: [ubuntu-latest, windows-latest, macos-13, macos-14]
           pyver: [cp39, cp310, cp311, cp312]
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vcpkg"]
+	path = vcpkg
+	url = https://github.com/microsoft/vcpkg

--- a/ci/buildwheel/install_deps.bat
+++ b/ci/buildwheel/install_deps.bat
@@ -1,0 +1,1 @@
+./vcpkg/bootstrap-vcpkg.bat

--- a/ci/buildwheel/install_deps.sh
+++ b/ci/buildwheel/install_deps.sh
@@ -3,12 +3,5 @@
 set -ex
 
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
-cd "$SCRIPT_DIR"
 
-echo "MACOSX_DEPLOYMENT_TARGET: [$MACOSX_DEPLOYMENT_TARGET]"
-echo "PWD: [$PWD]"
-
-brew install  --formulae eigen ../highfive.rb catch2
-brew uninstall --ignore-dependencies hdf5@1.10
-
-./install_hdf5.sh
+./vcpkg/bootstrap-vcpkg.sh

--- a/conda-recipes/conda_build_config.yaml
+++ b/conda-recipes/conda_build_config.yaml
@@ -1,8 +1,9 @@
 python:
-    - 3.8
     - 3.9
     - 3.10
     - 3.11
+    - 3.12
+    - 3.13
 
 blas_impl:      # [linux64 or win64]
     - openblas  # [linux64 or win64]

--- a/conda-recipes/smurff/meta.yaml
+++ b/conda-recipes/smurff/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - llvm-openmp             # [osx]
   host:
     - llvm-openmp             # [osx]
-    - mkl-devel               # [blas_impl == 'mkl']
+    - mkl-devel <2025         # [blas_impl == 'mkl']
     - openblas                # [blas_impl != 'mkl']
     - eigen
     - catch2
@@ -32,7 +32,7 @@ requirements:
     - setuptools_scm
   run:
     - python {{ python }}
-    - mkl                   # [blas_impl == 'mkl']
+    - mkl <2025             # [blas_impl == 'mkl']
     - openblas              # [blas_impl != 'mkl']
     - libboost              # [not win]
     - numpy

--- a/conda-recipes/smurff/meta.yaml
+++ b/conda-recipes/smurff/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: {{ environ.get("GIT_DESCRIBE_TAG", "0.99.9").lstrip("v") }}
 
 source:
-  path: ../..
+  git_url: ../..
 
 build:
     number: {{ GIT_DESCRIBE_NUMBER }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ before-all = "ci/buildwheel/install_deps.sh"
 "cmake.define.ENABLE_CMDLINE" = "OFF"
 "cmake.define.ENABLE_TESTS" = "OFF"
 "cmake.define.CMAKE_TOOLCHAIN_FILE" = "vcpkg/scripts/buildsystems/vcpkg.cmake"
+"cmake.define.VCPKG_TARGET_TRIPLET" = "x64-windows-static"
 
 [tool.cibuildwheel.windows]
 before-all = "ci\\buildwheel\\install_deps.bat"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,9 +63,6 @@ Homepage = "http://github.com/ExaScience/smurff"
 py_smurff = "smurff.cmdline:main"
 
 [tool.cibuildwheel]
-manylinux-x86_64-image = "vanderaa/manylinux2014_x86_64_smurff"
-musllinux-x86_64-image = "vanderaa/musllinux_1_2_x86_64_smurff"
-
 # We skip these:
 # - PyPy: never tested, pandas does not seem to work
 # - CPython 3.6: unsupported by scikit_build_core
@@ -76,13 +73,23 @@ skip = "pp* cp36-* cp37-* cp38-* *musl* *-win32 *i686"
 test-command = 'pytest -n auto {project}/python/test'
 test-requires = 'parameterized pytest pytest-xdist'
 
+manylinux-x86_64-image = "vanderaa/manylinux2014_x86_64_smurff"
+musllinux-x86_64-image = "vanderaa/musllinux_1_2_x86_64_smurff"
+
+# - cibuildwheel on macos -
+
 [tool.cibuildwheel.macos.config-settings]
-"cmake.define.HDF5_ROOT" = "/usr/local/hdf5"
 "cmake.define.ENABLE_BLAS" = "ON"
 "cmake.define.ENABLE_BOOST" = "OFF"
 "cmake.define.ENABLE_CMDLINE" = "OFF"
 "cmake.define.ENABLE_TESTS" = "OFF"
 "cmake.define.BLA_VENDOR" = "Apple"
+"cmake.define.CMAKE_TOOLCHAIN_FILE" = "vcpkg/scripts/buildsystems/vcpkg.cmake"
+
+[tool.cibuildwheel.macos]
+before-all = "ci/buildwheel/install_deps.sh"
+
+# - cibuildwheel on linux -
 
 [tool.cibuildwheel.linux.config-settings]
 "cmake.define.ENABLE_BLAS" = "ON"
@@ -91,9 +98,15 @@ test-requires = 'parameterized pytest pytest-xdist'
 "cmake.define.ENABLE_TESTS" = "OFF"
 "cmake.define.BLA_VENDOR" = "OpenBLAS"
 
-[tool.cibuildwheel.macos]
-before-all = "ci/buildwheel/install_deps.sh"
 
-# https://github.com/mcleantom/scikit_build_core_vcpkg
-#[tool.cibuildwheel.windows.config-settings]
-# "cmake.define.CMAKE_TOOLCHAIN_FILE" = "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+# - cibuildwheel on windows -
+
+[tool.cibuildwheel.windows.config-settings]
+"cmake.define.ENABLE_BLAS" = "OFF"
+"cmake.define.ENABLE_BOOST" = "OFF"
+"cmake.define.ENABLE_CMDLINE" = "OFF"
+"cmake.define.ENABLE_TESTS" = "OFF"
+"cmake.define.CMAKE_TOOLCHAIN_FILE" = "vcpkg/scripts/buildsystems/vcpkg.cmake"
+
+[tool.cibuildwheel.windows]
+before-all = "ci\\buildwheel\\install_deps.bat"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,8 @@ Homepage = "http://github.com/ExaScience/smurff"
 py_smurff = "smurff.cmdline:main"
 
 [tool.cibuildwheel]
+# Increase pip debugging output
+build-verbosity = 3
 # We skip these:
 # - PyPy: never tested, pandas does not seem to work
 # - CPython 3.6: unsupported by scikit_build_core

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,9 +67,7 @@ py_smurff = "smurff.cmdline:main"
 build-verbosity = 3
 # We skip these:
 # - PyPy: never tested, pandas does not seem to work
-# - CPython 3.6: unsupported by scikit_build_core
-# - CPython 3.7: unsupported by h5sparse
-# - CPython 3.8: removed from manylinux/musllinux
+# - CPython <= 3.8: unsupported
 # - i686 and win32: we do not care about 32bit
 skip = "pp* cp36-* cp37-* cp38-* *musl* *-win32 *i686"
 test-command = 'pytest -n auto {project}/python/test'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,3 +93,7 @@ test-requires = 'parameterized pytest pytest-xdist'
 
 [tool.cibuildwheel.macos]
 before-all = "ci/buildwheel/install_deps.sh"
+
+# https://github.com/mcleantom/scikit_build_core_vcpkg
+#[tool.cibuildwheel.windows.config-settings]
+# "cmake.define.CMAKE_TOOLCHAIN_FILE" = "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,12 +2,7 @@
   "name": "smurff",
   "version": "0.17.0",
   "dependencies": [
-    "boost-filesystem",
-    "boost-program-options",
-    "boost-system",
-    "catch2",
     "eigen3",
-    "highfive",
-    "pybind11"
+    "highfive"
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "smurff",
+  "version": "0.17.0",
+  "dependencies": [
+    "boost-filesystem",
+    "boost-program-options",
+    "boost-system",
+    "catch2",
+    "eigen3",
+    "highfive",
+    "pybind11"
+  ]
+}


### PR DESCRIPTION
- vcpkg for non-python dependencies
- python 3.9 -> 3.13
- do not use mkl 2025 